### PR TITLE
Add number funcs param & assignment -> defval

### DIFF
--- a/slept2resid.m
+++ b/slept2resid.m
@@ -1,4 +1,4 @@
-function varargout=slept2resid(slept,thedates,fitwhat,givenerrors,specialterms,CC,TH)
+function varargout=slept2resid(slept,thedates,fitwhat,givenerrors,specialterms,CC,TH,N)
 % [ESTsignal,ESTresid,ftests,extravalues,total,alphavarall,totalparams,
 %    totalparamerrors,totalfit,functionintegrals,alphavar]
 %       =SLEPT2RESID(slept,thedates,fitwhat,givenerrors,specialterms,CC,TH)
@@ -51,6 +51,8 @@ function varargout=slept2resid(slept,thedates,fitwhat,givenerrors,specialterms,C
 % CC           A cell array of the localization Slepian functions
 % TH           The region (proper string or XY coordinates) that you did the
 %               localization on (so we can integrate)
+% N          Number of largest eigenfunctions in which to expand.  By default
+%             rounds to the Shannon number.
 %            
 % OUTPUT:
 %
@@ -488,7 +490,7 @@ if nargout >= 5 && exist('CC') && exist('TH')
        XY=TH;
     end
     % Calculate the Shannon number for this basis
-    N=round((L+1)^2*spharea(XY));
+    defval('N',round((L+1)^2*spharea(XY)));
     
     % Make the coefficients with reference to some mean
     % If they already are, then this won't matter


### PR DESCRIPTION
In the `SyntheticCaseA` script, we have the following code:

````
if numfun(h) > 0
              % Estimate the total mass change
              % How is numfun(h) supposed to be involved here?
              [ESTsignal,ESTresid,ftests,extravalues,total,...
               alphavarall,totalparams,totalparamerrors,totalfit,...
               functionintegrals,alphavar] = slept2resid(slept,thedates,...
                [3 365.0],[],[],CC,TH,numfun(h));
               # ^ this was [1 365.0] originally
              allslopes{h}(counter) = totalparams(2)*365;
           else
# ...
````

This code presumes the existence of a parameter like the one I am proposing, and does not (on small regions) work without it.  I don't think my proposed change will break anything (fingers crossed), and if I understand the code in `SyntheticCaseA` correctly, I believe it will help make that code work on regions such as Iceland where the Shannon number is very small.

The alternative would be to round up the Shannon number by default, but I worry that this might have unintended consequences elsewhere in scripts which call this script already.