### PR TITLE
Fixed comment to mention Parpool not Matlabpool

### DIFF
--- a/getglaciers.m
+++ b/getglaciers.m
@@ -31,7 +31,7 @@ function varargout=getglaciers(region)
 % $FILES/GLACIERS/RGI_3_2/MATFILES/Regionname.mat
 % and after running it, will bybass the SHPFILES directory.
 % 
-% Open a MATLABPOOL and this will run in parallel, automatically
+% Open a PARPOOL and this will run in parallel, automatically
 %
 % IMPORTANT: 
 %


### PR DESCRIPTION
This is a completely trivial PR, it just updates a comment to reference the correct / updated parallel computing tool from Matlab (as Matlabpool is deprecated).