### PR TITLE
Reflect file nomenclature from `grace2plmt`

### DIFF
--- a/plmt2resid.m
+++ b/plmt2resid.m
@@ -45,9 +45,8 @@ function varargout=plmt2resid(plmt,thedates,fitwhat,givenerrors)
 % Last modified by charig-at-princeton.edu 5/24/2011
 % Last modified by fjsimons-at-alum.mit.edu 5/26/2011
 
-defval('xver',0)  
-defval('plmt',fullfile(getenv('IFILES'),'GRACE','CSR_alldata.mat'))
-defval('plmt',fullfile(getenv('IFILES'),'GRACE','GFZ_alldata.mat'))
+defval('xver',0)
+defval('plmt',fullfile(getenv('IFILES'),'GRACE','CSR_RL05_alldata.mat'))
 warning('off','MATLAB:divideByZero');
 
 if isstr(plmt)


### PR DESCRIPTION
This code asks for `CSR_alldata.mat`, which, I think, is a mistake.  That file does not appear to be created anywhere in any of the `Slepian` code.  My assumption is that we probably previously made that file before adding support for other data products at which point I'm guessing we added the data product name to the matlab file name.  This hunch [seems to be reflected in `plmt2diff`](https://github.com/csdms-contrib/slepian_delta/blob/27d935c4a55e23ff69398f78e5959edb621ca061/plmt2diff.m#L20), where the same `defval` happens, but with the updated name.

If I am right about this, then I think either we should accept my suggested edit to match `plmt2diff`, or, if data centers other than `CSR` are equally well supported in this code, then we might want to add data product and data center arguments in the style of the `slept2` `plmt`/`grace` files, and then construct the correct filename accordingly.