### PR TITLE
Update slept2resid.m

### DIFF
--- a/slept2resid.m
+++ b/slept2resid.m
@@ -104,10 +104,10 @@ function varargout=slept2resid(slept,thedates,fitwhat,givenerrors,specialterms,C
 %
 % Last modified by charig-at-princeton.edu  6/26/2012
 
-defval('xver',0)  
+defval('xver',0);  
 %defval('specialterms',{2 'periodic' 1728.1});
 defval('specialterms',{NaN});
-defval('slept','grace2slept(''CSR'',''greenland'',0.5,60,[],[],[],[],''SD'')')
+defval('slept','grace2slept(''CSR'',''greenland'',0.5,60,[],[],[],[],''SD'')');
 defval('extravalues',[]);
 
 if isstr(slept)
@@ -117,7 +117,9 @@ end
 
 % Initialize/Preallocate
 defval('givenerrors',ones(size(slept)));
-defval('fitwhat',[3 365.0])
+defval('fitwhat',[3 365.0]);
+defval('P2ftest',0);
+defval('P3ftest',0);
 
 % Handle the dates
 if length(thedates)==size(slept,1)


### PR DESCRIPTION
I got an error because these were not `defval` 'd to begin with.  In the style of `slept2resid_fgls`, I suggest adding these `defval` 's in near the top after `fitwhat`.

Also I added a couple of missing `;` 's for stylistic consistency, since I was making/suggesting edits anyway.